### PR TITLE
Fix EXP-4440, Add experiment lookup functionality

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 import requests
 from pytest_bdd import given, then
+from selenium.common.exceptions import JavascriptException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -45,6 +46,18 @@ def pytest_addoption(parser) -> None:
         action="store_true",
         default=None,
         help="Run private browsing test",
+    ),
+    parser.addoption(
+        "--experiment-slug",
+        action="store",
+        default=None,
+        help="Experiment slug from Experimenter",
+    ),
+    parser.addoption(
+        "--experiment-server",
+        action="store",
+        default="prod",
+        help="The server where the experiment is located, either stage or prod",
     )
 
 
@@ -69,12 +82,29 @@ def start_process(path, command):
         return process
 
 
+@pytest.fixture(name="get_experiment_json")
+def fixture_get_experiment_json(request):
+    experiment_slug = request.config.getoption("--experiment-slug")
+    slug_server = request.config.getoption("--experiment-server")
+
+    match slug_server:
+        case "prod":
+            url = (
+                f"https://experimenter.services.mozilla.com/api/v6/experiments/{experiment_slug}/"
+            )
+        case "stage":
+            url = f"https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v6/experiments/{experiment_slug}/"  # noqa: E501
+
+    return requests.get(url).json()
+
+
 @pytest.fixture(name="enroll_experiment", autouse=True)
 def fixture_enroll_experiment(
     request: typing.Any,
     selenium: typing.Any,
-    variables: dict,
     check_ping_for_experiment: object,
+    get_experiment_json: object,
+    experiment_slug: str,
 ) -> typing.Any:
     """Fixture to enroll into an experiment"""
     experiment_branch = request.config.getoption("--experiment-branch")
@@ -91,16 +121,22 @@ def fixture_enroll_experiment(
         ExperimentManager.ExperimentManager.forceEnroll(recipe, branch);
     """
 
-    with selenium.context(selenium.CONTEXT_CHROME):
-        selenium.execute_script(script, json.dumps(variables), experiment_branch)
-    assert (
-        check_ping_for_experiment(f"optin-{variables['slug']}") is not None
-    ), "Experiment not found in telemetry"
+    try:
+        with selenium.context(selenium.CONTEXT_CHROME):
+            selenium.execute_script(script, json.dumps(get_experiment_json), experiment_branch)
+    except JavascriptException as e:
+        if "slug" in str(e):
+            raise (Exception("Experiment slug was not found in the experiment."))
+    else:
+        assert (
+            check_ping_for_experiment(f"optin-{experiment_slug}") is not None
+        ), "Experiment not found in telemetry"
+        logging.info("Experiment loaded successfully!")
 
 
 @pytest.fixture(name="experiment_slug")
-def fixture_experiment_slug(variables: dict) -> typing.Any:
-    return f"optin-{variables['slug']}"
+def fixture_experiment_slug(request) -> typing.Any:
+    return request.config.getoption("--experiment-slug")
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds the capability to provide the experiment slug and server type `stage` or `prod` and grab the json from the servers and load it into the test.