### PR TITLE
Fix #160, add slug and branch reporting to HTML reports.

### DIFF
--- a/.github/workflows/android_manual.yml
+++ b/.github/workflows/android_manual.yml
@@ -160,8 +160,8 @@ jobs:
           pipenv install
           pipenv install pytest-rerunfailures
           pipenv run python generate_smoke_tests.py
-          echo "PIPENV COMMAND: 'pipenv run pytest --experiment  ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} ${{ inputs.extra-arguments }} --reruns 1'"
-          pipenv run pytest --experiment ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} ${{ inputs.extra-arguments }} --reruns 1
+          echo "TEST COMMAND: pipenv run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }} ${{ inputs.extra-arguments }} --reruns 1"
+          pipenv run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }} ${{ inputs.extra-arguments }} --reruns 1
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/ios_manual.yml
+++ b/.github/workflows/ios_manual.yml
@@ -115,7 +115,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: ${{ inputs.slug }} HTML Test Report on firefox v${{ matrix.firefox }} branch ${{ matrix.branch }}
-          path: /Users/runner/work/klaatu/klaatu/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/results/index.html
+          path: /Users/runner/work/klaatu/klaatu/firefox-ios/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/results/index.html
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/ios_manual.yml
+++ b/.github/workflows/ios_manual.yml
@@ -101,8 +101,8 @@ jobs:
           xcrun simctl shutdown all
           export SIMULATOR_UDID=$(python get_specific_device_udid.py)
           poetry run python generate_smoke_tests.py
-          echo "TEST COMMAND: poetry run pytest --experiment ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} ${{ inputs.extra-arguments }} --reruns 1"
-          poetry run pytest --experiment ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} ${{ inputs.extra-arguments }} --reruns 1
+          echo "TEST COMMAND: poetry run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }}  ${{ inputs.extra-arguments }} --reruns 1"
+          poetry run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }}  ${{ inputs.extra-arguments }} --reruns 1
       - name: Archive Results
         if: ${{ always() }}
         run: zip -r results.zip /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult

--- a/tests/android/conftest.py
+++ b/tests/android/conftest.py
@@ -155,10 +155,10 @@ def fixture_experiment_data(experiment_url, request):
 
 
 @pytest.fixture(name="experiment_url", scope="module")
-def fixture_experiment_url(request, variables):
+def fixture_experiment_url(request, variables, experiment_slug):
     url = None
 
-    if slug := request.config.getoption("--experiment"):
+    if slug := experiment_slug:
         # Build URL from slug
         match request.config.getoption("--experiment-server"):
             case "prod":

--- a/tests/ios/conftest.py
+++ b/tests/ios/conftest.py
@@ -188,10 +188,10 @@ def fixture_experiment_data(experiment_url):
 
 
 @pytest.fixture(name="experiment_url", scope="module")
-def fixture_experiment_url(request, variables):
+def fixture_experiment_url(request, variables, experiment_slug):
     url = None
 
-    if slug := request.config.getoption("--experiment"):
+    if slug := experiment_slug:
         # Build URL from slug
         match request.config.getoption("--experiment-server"):
             case "prod":


### PR DESCRIPTION
This adds a slug, branch and Firefox version to the generated HTML reports.

![image](https://github.com/user-attachments/assets/a6ba9a3e-7ce6-4f48-ba95-85d6efc5480b)

Fixes #160 
