### PR TITLE
chore(actions): Fix for potential selenium manager timeout error.

### DIFF
--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -73,7 +73,10 @@ jobs:
         run: |
           openssl req -x509 -newkey rsa:2048 -keyout search_files/server.key -out search_files/server.cert -days 365 -nodes -subj "//CN=localhost"
       - name: Run Tests
-        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --private-browsing-enabled --firefox-path="C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" ${{ inputs.extra-arguments }}
+        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --private-browsing-enabled --firefox-path "C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" --driver-path "C:\SeleniumWebDrivers\GeckoDriver\geckodriver.exe" ${{ inputs.extra-arguments }}
+        env:
+          SE_BROWSER_PATH: 'C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe'
+          SE_OFFLINE: true
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,9 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 [pytest]
-addopts = -vvv -p no:logging -s -p no:warnings --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html --full-trace
+addopts = -vvv -p no:warnings -s --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html --full-trace
 sensitive_url = mozilla\.(com|org)
 log_cli = true
+log_cli_level = info
 markers =
     expire_experiment: mark a test that will need the experiment to be expired
     last: mark a test to run last

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,11 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 [pytest]
-addopts = -vvv -p no:warnings --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html
+addopts = -vvv -p no:logging -s --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html
 sensitive_url = mozilla\.(com|org)
 log_cli = true
-log_cli_level = info
-markers = 
+markers =
     expire_experiment: mark a test that will need the experiment to be expired
     last: mark a test to run last
     first: mark a test to run first

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 [pytest]
-addopts = -vvv -p no:logging -s --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html
+addopts = -vvv -p no:logging -s -p no:warnings --reruns 1 --reruns-delay 5 --self-contained-html --html=tests/report.html --full-trace
 sensitive_url = mozilla\.(com|org)
 log_cli = true
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def fixture_experiment_json(request):
 def fixture_enroll_experiment(
     request: typing.Any,
     selenium: typing.Any,
-    telemetry_event_check: object,
+    # telemetry_event_check: object,
     experiment_json: object,
     experiment_slug: str,
 ) -> typing.Any:
@@ -150,11 +150,11 @@ def fixture_enroll_experiment(
     except JavascriptException as e:
         if "slug" in str(e):
             raise (Exception("Experiment slug was not found in the experiment."))
-    else:
-        assert telemetry_event_check(
-            f"optin-{experiment_slug}", event="enrollment"
-        ), "Experiment not found in telemetry"
-        logging.info("Experiment loaded successfully!")
+    # else:
+    #     assert telemetry_event_check(
+    #         f"optin-{experiment_slug}", event="enrollment"
+    #     ), "Experiment not found in telemetry"
+    logging.info("Experiment loaded successfully!")
 
 
 @pytest.fixture(name="experiment_slug", scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,14 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 
+logger = logging.getLogger('selenium')
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+logging.getLogger('selenium.webdriver.remote').setLevel(logging.DEBUG)
+logging.getLogger('selenium.webdriver.common').setLevel(logging.DEBUG)
+
+
 def pytest_addoption(parser) -> None:
     parser.addoption(
         "--experiment-recipe",
@@ -144,7 +152,7 @@ def fixture_enroll_experiment(
             raise (Exception("Experiment slug was not found in the experiment."))
     else:
         assert telemetry_event_check(
-            f"optin-{experiment_slug}", event="enroll"
+            f"optin-{experiment_slug}", event="enrollment"
         ), "Experiment not found in telemetry"
         logging.info("Experiment loaded successfully!")
 
@@ -347,6 +355,8 @@ def fixture_telemetry_event_check(trigger_experiment_loader, selenium):
         fetch_events = """
             return Glean.nimbusEvents.enrollment.testGetValue("events");
         """
+
+        logging.info("BEGIN TELEMETRY EVENT CHECKS")
 
         with selenium.context(selenium.CONTEXT_CHROME):
             control = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 
-logger = logging.getLogger('selenium')
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-logger.addHandler(handler)
-logging.getLogger('selenium.webdriver.remote').setLevel(logging.DEBUG)
-logging.getLogger('selenium.webdriver.common').setLevel(logging.DEBUG)
-
-
 def pytest_addoption(parser) -> None:
     parser.addoption(
         "--experiment-recipe",
@@ -161,11 +153,6 @@ def fixture_enroll_experiment(
         control = telemetry_event_check(f"optin-{experiment_slug}", "enrollment")
         if time.time() > timeout:
             raise AssertionError("Experiment enrollment was never seen in ping Data")
-        time.sleep(5)
-
-    # assert telemetry_event_check(
-    #     f"optin-{experiment_slug}", event="enrollment"
-    # ), "Experiment not found in telemetry"
     logging.info("Experiment loaded successfully!")
 
 
@@ -372,9 +359,9 @@ def fixture_telemetry_event_check(trigger_experiment_loader, selenium):
                 nimbus_events = selenium.execute_script(script)
 
             logging.info(f"nimbus events: {nimbus_events}")
-            assert event in next(event["name"] for event in nimbus_events)
-            assert experiment in next(
-                event["extra"]["experiment"] for event in nimbus_events
+            assert any(
+                events["name"] == event and events["extra"]["experiment"] == experiment
+                for events in nimbus_events
             )
             return True
         except (AssertionError, TypeError):


### PR DESCRIPTION
Because

- Selenium manager can sometimes cause errors with trying to download Firefox
- We want to remove the `ping-server` eventually and just use the built in tooling for checking events.

This commit

- Disables Selenium Managers downloading capabilities.
- Adds functionality to check nimbus events using the built in Glean testing tools.
Fixes #210 