### PR TITLE
chore(actions): Add run-name to actions workflows.

### DIFF
--- a/.github/workflows/android_manual.yml
+++ b/.github/workflows/android_manual.yml
@@ -40,6 +40,9 @@ on:
         default: ''
         required: false
         type: string
+
+run-name: Experiment ${{ inputs.feature-name }} tests for ${{ inputs.slug }}
+
 jobs:
   android-klaatu-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios_manual.yml
+++ b/.github/workflows/ios_manual.yml
@@ -41,6 +41,9 @@ on:
         default: ''
         required: false
         type: string
+
+run-name: Experiment ${{ inputs.feature-name }} tests for ${{ inputs.slug }}
+
 jobs:
   iOS-klaatu-tests:
     runs-on: macos-14

--- a/.github/workflows/linux_manual.yml
+++ b/.github/workflows/linux_manual.yml
@@ -24,6 +24,9 @@ on:
         type: string
 env:
   MOZ_HEADLESS: 1
+
+run-name: Experiment Smoke tests for ${{ inputs.slug }}
+
 jobs:
   klaatu-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -25,6 +25,9 @@ on:
         type: string
 env:
   MOZ_HEADLESS: 1
+
+run-name: Experiment Smoke tests for ${{ inputs.slug }}
+
 jobs:
   klaatu-tests:
     runs-on: windows-latest


### PR DESCRIPTION
Because

- We need to query the GitHub actions API for our integration into experimenter

This commit

- Adds the capability to filter by `run-name` to aid us in finding the correct workflow run for each experiment that gets tested.

fixes #211 