### PR TITLE
chore(project): Add capability to specify servers on desktop workflows.

### DIFF
--- a/.github/workflows/linux_manual.yml
+++ b/.github/workflows/linux_manual.yml
@@ -12,6 +12,14 @@ on:
         default: 'an-awesome-experiment'
         required: true
         type: string
+      server:
+        description: 'Experimenter Server'
+        default: 'prod'
+        required: false
+        type: choice
+        options:
+          - stage
+          - prod
       firefox-version:
         description: 'The Firefox Version(s) you want to test'
         default: "['latest-beta', 'latest', '123.0']"
@@ -58,7 +66,7 @@ jobs:
             openssl req -x509 -newkey rsa:2048 -keyout search_files/server.key -out search_files/server.cert -days 365 -nodes -subj "/CN=localhost"
       - name: Run Tests
         run: |
-          tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --private-browsing-enabled --firefox-path="/opt/hostedtoolcache/firefox/${{ matrix.firefox }}/x64/firefox" ${{ inputs.extra-arguments }}
+          tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.server}} --private-browsing-enabled --firefox-path="/opt/hostedtoolcache/firefox/${{ matrix.firefox }}/x64/firefox" ${{ inputs.extra-arguments }}
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -13,6 +13,14 @@ on:
         default: 'an-awesome-experiment'
         required: true
         type: string
+      server:
+        description: 'Experimenter Server'
+        default: 'prod'
+        required: false
+        type: choice
+        options:
+          - stage
+          - prod
       firefox-version:
         description: 'The Firefox Version(s) you want to test'
         default: "['latest-beta', 'latest', '123.0']"
@@ -76,7 +84,7 @@ jobs:
         run: |
           openssl req -x509 -newkey rsa:2048 -keyout search_files/server.key -out search_files/server.cert -days 365 -nodes -subj "//CN=localhost"
       - name: Run Tests
-        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --private-browsing-enabled --firefox-path "C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" --driver-path "C:\SeleniumWebDrivers\GeckoDriver\geckodriver.exe" ${{ inputs.extra-arguments }}
+        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.server}} --private-browsing-enabled --firefox-path "C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" --driver-path "C:\SeleniumWebDrivers\GeckoDriver\geckodriver.exe" ${{ inputs.extra-arguments }}
         env:
           SE_BROWSER_PATH: 'C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe'
           SE_OFFLINE: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def fixture_experiment_json(request):
         case "prod":
             url = f"https://experimenter.services.mozilla.com/api/v6/experiments/{experiment_slug}/"  # noqa: E501
         case "stage":
-            url = f"https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v6/experiments/{experiment_slug}/"  # noqa: E501
+            url = f"https://stage.experimenter.nonprod.webservices.mozgcp.net/api/v6/experiments/{experiment_slug}/"  # noqa: E501
     return requests.get(url).json()
 
 


### PR DESCRIPTION
Because

- We need to be able to specify which server we want to test against when requesting a test against a desktop experiment

This commit

- Adds the necessary actions updates to facilitate specifying a server
- Update the stage URL