### PR TITLE
fix(tests): Add delay and retry to search addon installation.

### DIFF
--- a/.github/workflows/android_manual.yml
+++ b/.github/workflows/android_manual.yml
@@ -23,10 +23,10 @@ on:
         required: true
         type: choice
         options:
-          - smoke_test
+          - smoke
           - messaging_survey
           - messaging_homescreen
-      experiment-server:
+      server:
         description: 'The server that the experiment exists on (stage/prod)'
         default: 'prod'
         required: true
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
@@ -87,12 +87,12 @@ jobs:
           java-version: '17'
       - name: Cache Fenix Test APK
         id: cache_test_apk
-        uses: actions/cache@v2
+        uses: actions/cache@v4.3.0
         with:
           path: klaatu/android-debug-test-v${{ matrix.firefox }}.apk
           key: android-debug-test-v${{ matrix.firefox }}
       - name: Cache Fenix APK
-        uses: actions/cache@v2
+        uses: actions/cache@v4.3.0
         with:
           path: klaatu/fenix-debug-v${{ matrix.firefox }}.apk
           key: fenix-debug-v${{ matrix.firefox }}

--- a/.github/workflows/ios_manual.yml
+++ b/.github/workflows/ios_manual.yml
@@ -27,7 +27,7 @@ on:
           - smoke
           - messaging_survey
           - messaging-new-tab-card
-      experiment-server:
+      server:
         description: 'The server that the experiment exists on (stage/prod)'
         default: 'prod'
         required: true
@@ -46,7 +46,7 @@ run-name: Experiment ${{ inputs.feature-name }} tests for ${{ inputs.slug }}
 
 jobs:
   iOS-klaatu-tests:
-    runs-on: macos-14
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -62,9 +62,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.3.0
         with:
           path: /Users/runner/Library/Developer/Xcode/DerivedData/**/
           key: xcode-firefox-v${{ matrix.firefox }}-cache

--- a/.github/workflows/linux_manual.yml
+++ b/.github/workflows/linux_manual.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Setup tests
         shell: bash
         run: ./setup_script.sh

--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -38,7 +38,7 @@ run-name: Experiment Smoke tests for ${{ inputs.slug }}
 
 jobs:
   klaatu-tests:
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 from pytest_bdd import given, then
 from pytest_metadata.plugin import metadata_key
-from selenium.common.exceptions import JavascriptException
+from selenium.common.exceptions import JavascriptException, NoSuchElementException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -691,10 +691,18 @@ def check_new_tab(selenium):
 def setup_browser(selenium, setup_search_test):
     selenium.implicitly_wait(5)
     path = os.path.abspath("tests/fixtures/search_addon")
-    selenium.install_addon(path, temporary=True)
-    with selenium.context(selenium.CONTEXT_CHROME):
-        root = selenium.find_element(By.CSS_SELECTOR, "#addon-webext-defaultsearch-notification")
-        root.find_element(By.CSS_SELECTOR, ".popup-notification-primary-button").click()
+    time.sleep(5)
+    count = 12
+    while count >= 12:
+        try:
+            selenium.install_addon(path, temporary=True)
+            with selenium.context(selenium.CONTEXT_CHROME):
+                root = selenium.find_element(By.CSS_SELECTOR, "#addon-webext-defaultsearch-notification")
+                root.find_element(By.CSS_SELECTOR, ".popup-notification-primary-button").click()
+        except NoSuchElementException:
+            time.sleep(10)
+        else:
+            break
     setup_search_test()
     logging.info("Custom search enabled\n")
     script = """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 from pytest_bdd import given, then
 from pytest_metadata.plugin import metadata_key
-from selenium.common.exceptions import JavascriptException, NoSuchElementException
+from selenium.common.exceptions import JavascriptException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -614,7 +614,7 @@ def fixture_setup_search_test(selenium, firefox):
                     callback(false);
                 }
             })();
-        """
+        """  # noqa
         with selenium.context(selenium.CONTEXT_CHROME):
             selenium.execute_script(test_data)
             selenium.execute_async_script(search_engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ def fixture_enroll_experiment(
         if time.time() > timeout:
             raise AssertionError("Experiment enrollment was never seen in ping Data")
     logging.info("Experiment loaded successfully!")
+    time.sleep(15)
 
 
 @pytest.fixture(name="experiment_slug", scope="session", autouse=True)
@@ -408,6 +409,7 @@ def fixture_navigate_using_url_bar(selenium, cmd_or_ctrl_button):
             text = "http://localhost:8000"
         with selenium.context(selenium.CONTEXT_CHROME):
             el = selenium.find_element(By.CSS_SELECTOR, "#urlbar-input")
+            WebDriverWait(selenium, 60).until(EC.element_to_be_clickable(el))
             if use_clipboard:
                 ActionChains(selenium).move_to_element(el).pause(1).click().pause(1).key_down(
                     cmd_or_ctrl_button
@@ -590,8 +592,32 @@ def fixture_setup_search_test(selenium, firefox):
         ];
         SearchSERPTelemetry.overrideSearchTelemetryForTests(testProvider);
         """
+
+        search_engine = """
+        const callback = arguments[0];
+            (async function () {
+                try {
+                    installedEngines = await Services.search.getAppProvidedEngines();
+                    userEngine = await Services.search.addUserEngine({
+                        name: "Moz Search",
+                        url: "https://localhost:8888/searchTelemetryAd.html?s={searchTerms}&abc=ff",
+                        suggest_url: "https://localhost:8888/searchSuggestionEngine.sjs?query={searchTerms}",
+                        alias: "mzsrch",
+                    });
+                    installedEngines.push(userEngine);
+                    Services.search.setDefault(
+                        Services.search.getEngineByName("Moz Search"),
+                        Ci.nsISearchService.CHANGE_REASON_USER_SEARCHBAR
+                        );
+                    callback(true);
+                } catch (err) {
+                    callback(false);
+                }
+            })();
+        """
         with selenium.context(selenium.CONTEXT_CHROME):
             selenium.execute_script(test_data)
+            selenium.execute_async_script(search_engine)
 
     return _
 
@@ -690,20 +716,6 @@ def check_new_tab(selenium):
 )
 def setup_browser(selenium, setup_search_test):
     selenium.implicitly_wait(5)
-    path = os.path.abspath("tests/fixtures/search_addon")
-    time.sleep(5)
-    selenium.install_addon(path, temporary=True)
-    # count = 12
-    # while count >= 12:
-    #     try:
-    #         selenium.install_addon(path, temporary=True)
-    #         with selenium.context(selenium.CONTEXT_CHROME):
-    #             root = selenium.find_element(By.CSS_SELECTOR, "#addon-webext-defaultsearch-notification")
-    #             root.find_element(By.CSS_SELECTOR, ".popup-notification-primary-button").click()
-    #     except NoSuchElementException:
-    #         time.sleep(10)
-    #     else:
-    #         break
     setup_search_test()
     logging.info("Custom search enabled\n")
     script = """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -692,17 +692,18 @@ def setup_browser(selenium, setup_search_test):
     selenium.implicitly_wait(5)
     path = os.path.abspath("tests/fixtures/search_addon")
     time.sleep(5)
-    count = 12
-    while count >= 12:
-        try:
-            selenium.install_addon(path, temporary=True)
-            with selenium.context(selenium.CONTEXT_CHROME):
-                root = selenium.find_element(By.CSS_SELECTOR, "#addon-webext-defaultsearch-notification")
-                root.find_element(By.CSS_SELECTOR, ".popup-notification-primary-button").click()
-        except NoSuchElementException:
-            time.sleep(10)
-        else:
-            break
+    selenium.install_addon(path, temporary=True)
+    # count = 12
+    # while count >= 12:
+    #     try:
+    #         selenium.install_addon(path, temporary=True)
+    #         with selenium.context(selenium.CONTEXT_CHROME):
+    #             root = selenium.find_element(By.CSS_SELECTOR, "#addon-webext-defaultsearch-notification")
+    #             root.find_element(By.CSS_SELECTOR, ".popup-notification-primary-button").click()
+    #     except NoSuchElementException:
+    #         time.sleep(10)
+    #     else:
+    #         break
     setup_search_test()
     logging.info("Custom search enabled\n")
     script = """


### PR DESCRIPTION
Because:
- There have been some telemetry errors lately due to the installed search provider addon.

This commit:
- Removes the search provider addon and just installs one via the console.
- Updates the mobile workflows to match the desktop one
- Updates the actions/cache version within the mobile workflows