### PR TITLE
chore(project): Update android actions file and steps for testing.

### DIFF
--- a/.github/workflows/android_manual.yml
+++ b/.github/workflows/android_manual.yml
@@ -23,7 +23,7 @@ on:
         required: true
         type: choice
         options:
-          - smoke
+          - smoke_test
           - messaging_survey
           - messaging_homescreen
       server:
@@ -51,11 +51,12 @@ jobs:
         matrix:
           firefox: ${{ fromJSON(inputs.firefox-version) }}
           branch: ${{ fromJSON(inputs.branch) }}
+          api-level: [34]
     name: ${{ inputs.feature-name }} tests for ${{ inputs.slug }} on firefox android ${{ matrix.firefox }} branch ${{ matrix.branch }}
     steps:
       - name: Set FF Version for downloader
         id: ff-version
-        run: | 
+        run: |
           version=${{ matrix.firefox }}
           major_version=$(echo $version | cut -d'.' -f1)
           echo "FF_VERSION=$major_version" >> "$GITHUB_OUTPUT"
@@ -63,110 +64,61 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: klaatu
-      - name: Clone gecko-dev
+      - name: Clone mozilla central
         uses: actions/checkout@v4
         with:
           sparse-checkout: mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix
-          repository: mozilla/gecko-dev
-          path: gecko-dev
-      - name: Clone firefox-android-github
-        uses: actions/checkout@v4
-        if: matrix.firefox < '126.0.0'
-        with:
-          repository: mozilla-mobile/firefox-android
-          ref: "releases_v${{ steps.ff-version.outputs.FF_VERSION }}"
-          path: firefox-android
+          repository: mozilla-firefox/firefox
+          path: firefox
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '17'
-      - name: Cache Fenix Test APK
-        id: cache_test_apk
-        uses: actions/cache@v4.3.0
-        with:
-          path: klaatu/android-debug-test-v${{ matrix.firefox }}.apk
-          key: android-debug-test-v${{ matrix.firefox }}
-      - name: Cache Fenix APK
-        uses: actions/cache@v4.3.0
-        with:
-          path: klaatu/fenix-debug-v${{ matrix.firefox }}.apk
-          key: fenix-debug-v${{ matrix.firefox }}
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Download android images
-        run: |
-          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --update
-          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
-          echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "tools"
-      - name: Set PATHs
-        run: |
-          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/" >> $GITHUB_PATH
-          echo "$ANDROID_SDK_ROOT/platform-tools" >> $GITHUB_PATH
-          echo "$ANDROID_SDK_ROOT/emulator" >> $GITHUB_PATH      
-      - name: Start emulator
-        run: |
-          avdmanager create avd -n pixel_3a -k "system-images;android-34;google_apis;x86_64" --device "pixel_3a"
-          emulator -avd pixel_3a -no-window -no-snapshot -screen no-touch -noaudio -memory 2048 -no-boot-anim -accel on -camera-back none -gpu off &
-          adb wait-for-device
-          boot_completed="0"
-          while [ "$boot_completed" != "1" ]; do
-              boot_completed=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
-              if [ "$boot_completed" != "1" ]; then
-                  echo "Waiting for emulator to boot..."
-                  sleep 1
-              fi
-          done
-      - name: Download and install Android files
-        if: |
-          (steps.cache_test_apk.outputs.cache-hit != 'true') &&
-          (matrix.firefox > '125.0.0')
-        run: |
-          cd klaatu
-          pip3 install virtualenv poetry
-          poetry install --no-root
-          firefox_version=$(echo "${{ matrix.firefox }}" | tr '.' '_')
-          poetry run python utilities/get_android_apks.py --firefox-version=${{ matrix.firefox }}
-          adb devices
-          adb install android-debug-test-v${{ matrix.firefox }}.apk
-          adb install fenix-debug-v${{ matrix.firefox }}.apk
-        env:
-          ANDROID_SDK_HOME: $ANDROID_HOME
-          ANDROID_NDK_HOME: $ANDROID_NDK_HOME
-      - name: Build  and install Android version sub 126
-        if: matrix.firefox < '126.0.0'
-        run: |
-          cd firefox-android/fenix
-          ./gradlew clean app:assembleFenixDebugAndroidTest
-          adb install app/build/outputs/apk/androidTest/fenix/debug/app-fenix-debug-androidTest.apk
-          mv app/build/outputs/apk/androidTest/fenix/debug/app-fenix-debug-androidTest.apk /home/runner/work/klaatu/klaatu/android-debug-test-v${{ matrix.firefox }}.apk
-          ./gradlew clean app:assembleFenixDebug
-          adb install app/build/outputs/apk/fenix/debug/app-fenix-x86_64-debug.apk
-          mv app/build/outputs/apk/fenix/debug/app-fenix-x86_64-debug.apk /home/runner/work/klaatu/klaatu/fenix-debug-v${{ matrix.firefox }}.apk
-        env:
-          ANDROID_SDK_HOME: $ANDROID_HOME
-          ANDROID_NDK_HOME: $ANDROID_NDK_HOME
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
       - name: Install Nimbus CLI
-        run: curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash  
-      - name: Run Tests
-        run: |
-          cp -rf klaatu/tests/android/* gecko-dev/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
-          cd gecko-dev/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
-          pip3 install virtualenv poetry pipenv
-          pipenv install
-          pipenv install pytest-rerunfailures
-          pipenv run python generate_smoke_tests.py
-          echo "TEST COMMAND: pipenv run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }} ${{ inputs.extra-arguments }} --reruns 1"
-          pipenv run pytest --experiment-slug ${{ inputs.slug }} --experiment-branch ${{ matrix.branch }} --experiment-server ${{ inputs.experiment-server }} --experiment-feature ${{ inputs.feature-name }} --firefox-version ${{ matrix.firefox }} ${{ inputs.extra-arguments }} --reruns 1
+        run: curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash
+      - name: Fetch Fenix APKs from CircleCI
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          CIRCLECI_BRANCH: update_firefox_versions
+          CIRCLECI_OUTPUT_DIR: .
+          CIRCLECI_JOB_NAME: Build\ Fenix\ APKs
+        working-directory: klaatu
+        run: ./utilities/fetch_circleci_apks.sh
+      - name: Setup Emulator and run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          arch: x86_64
+          profile: pixel_3a
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          cores: 4
+          ram-size: 4096M
+          script: 'SLUG="${{ inputs.slug }}" BRANCH="${{ matrix.branch }}" EXPERIMENT_SERVER="${{ inputs.server }}" FEATURE_NAME="${{ inputs.feature-name }}" FIREFOX_VERSION="${{ matrix.firefox }}" EXTRA_ARGUMENTS="${{ inputs.extra-arguments }}" ./klaatu/utilities/start_android_klaatu_tests.sh'
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ inputs.slug }} HTML Test Report on firefox v${{ matrix.firefox }} branch ${{ matrix.branch }}
-          path: /home/runner/work/klaatu/klaatu/gecko-dev/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/results/index.html
+          path: /home/runner/work/klaatu/klaatu/firefox/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/results/index.html

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,2 @@
+nimbus.remote-settings.url=http://10.0.2.2:8888/
+glean.custom.server.url="http://10.0.2.2:5000/"

--- a/tests/android/variables.yaml
+++ b/tests/android/variables.yaml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 urls:
-  stage_server: "https://stage.experimenter.nonprod.dataops.mozgcp.net"
+  stage_server: "https://stage.experimenter.nonprod.webservices.mozgcp.net"
   prod_server: "https://experimenter.services.mozilla.com"
   telemetry_server: "http://127.0.0.1:5000"
 smoke_tests:

--- a/utilities/fetch_circleci_apks.sh
+++ b/utilities/fetch_circleci_apks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Fetch APK artifacts from CircleCI mozilla/experimenter builds
+# This script is designed for use in GitHub Actions CI
+
+set -e
+
+ORG="${CIRCLECI_ORG:-mozilla}"
+REPO="${CIRCLECI_REPO:-experimenter}"
+BRANCH="${CIRCLECI_BRANCH:-main}"
+OUTPUT_DIR="${CIRCLECI_OUTPUT_DIR:-.}"
+WORKFLOW_NAME="${CIRCLECI_WORKFLOW_NAME:-}"
+JOB_NAME="${CIRCLECI_JOB_NAME:-}"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Fetching APK artifacts from CircleCI"
+echo "Organization: $ORG"
+echo "Repository: $REPO"
+echo "Branch: $BRANCH"
+echo "Output directory: $OUTPUT_DIR"
+
+# Check if requests library is installed
+if ! python3 -c "import requests" 2>/dev/null; then
+    echo "Installing required Python dependencies..."
+    pip3 install requests
+fi
+
+CMD="python3 $SCRIPT_DIR/get_circleci_apks.py --org $ORG --repo $REPO --branch $BRANCH --output-dir $OUTPUT_DIR"
+
+if [ -n "$WORKFLOW_NAME" ]; then
+    CMD="$CMD --workflow-name $WORKFLOW_NAME"
+fi
+
+if [ -n "$JOB_NAME" ]; then
+    CMD="$CMD --job-name $JOB_NAME"
+fi
+
+eval $CMD
+
+exit_code=$?
+
+if [ $exit_code -eq 0 ]; then
+    echo "✓ APK artifacts downloaded successfully"
+    ls -lh "$OUTPUT_DIR"/*.apk 2>/dev/null || echo "Warning: No APK files found in output directory"
+else
+    echo "✗ Failed to download APK artifacts"
+    exit 1
+fi
+
+exit 0

--- a/utilities/get_circleci_apks.py
+++ b/utilities/get_circleci_apks.py
@@ -1,0 +1,280 @@
+"""
+Script to automatically find and download APK artifacts from CircleCI jobs in mozilla/experimenter repo.
+
+This script is designed for CI usage - it will automatically fetch the most recent successful
+APK artifacts without requiring user input.
+
+Usage:
+    # Fetch APKs from most recent successful build on main branch
+    python get_circleci_apks.py
+
+    # Fetch from specific branch
+    python get_circleci_apks.py --branch main
+
+    # Fetch specific job
+    python get_circleci_apks.py --job-name build-fenix
+
+Environment Variables:
+    CIRCLECI_TOKEN: CircleCI API token (required for private repos)
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+
+import requests
+
+
+class CircleCIArtifactFetcher:
+    """Fetches APK artifacts from CircleCI jobs."""
+
+    BASE_URL = "https://circleci.com/api/v2"
+
+    def __init__(self, token: Optional[str] = None):
+        """
+        Initialize the fetcher.
+
+        Args:
+            token: CircleCI API token. If not provided, will try to get from CIRCLECI_TOKEN env var.
+        """
+        self.token = token or os.environ.get("CIRCLECI_TOKEN")
+        self.headers = {}
+        if self.token:
+            self.headers["Circle-Token"] = self.token
+
+    def get_recent_pipelines(
+        self,
+        org: str,
+        repo: str,
+        branch: Optional[str] = None,
+        limit: int = 20
+    ) -> List[Dict[str, Any]]:
+        """Get recent pipelines for a project."""
+        url = f"{self.BASE_URL}/project/github/{org}/{repo}/pipeline"
+        params = {}
+        if branch:
+            params["branch"] = branch
+
+        response = requests.get(url, headers=self.headers, params=params)
+        response.raise_for_status()
+
+        data = response.json()
+        return data.get("items", [])[:limit]
+
+    def get_pipeline_workflows(self, pipeline_id: str) -> List[Dict[str, Any]]:
+        """Get workflows for a specific pipeline."""
+        url = f"{self.BASE_URL}/pipeline/{pipeline_id}/workflow"
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+
+        data = response.json()
+        return data.get("items", [])
+
+    def get_workflow_jobs(self, workflow_id: str) -> List[Dict[str, Any]]:
+        """Get jobs for a specific workflow."""
+        url = f"{self.BASE_URL}/workflow/{workflow_id}/job"
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+
+        data = response.json()
+        return data.get("items", [])
+
+    def get_job_artifacts(self, job_number: int, org: str, repo: str) -> List[Dict[str, Any]]:
+        """Get artifacts for a specific job."""
+        url = f"{self.BASE_URL}/project/github/{org}/{repo}/{job_number}/artifacts"
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+
+        data = response.json()
+        return data.get("items", [])
+
+    def download_artifact(self, artifact_url: str, output_path: Path) -> None:
+        """Download an artifact to a file."""
+        response = requests.get(artifact_url, headers=self.headers, stream=True)
+        response.raise_for_status()
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+    def find_and_download_apks(
+        self,
+        org: str,
+        repo: str,
+        output_dir: Path,
+        branch: Optional[str] = None,
+        workflow_name: Optional[str] = None,
+        job_name: Optional[str] = None,
+    ) -> int:
+        """
+        Find and download APK artifacts from the most recent successful job.
+
+        Returns:
+            Number of APKs downloaded
+        """
+        print(f"Searching for APK artifacts in {org}/{repo}")
+        if branch:
+            print(f"  Branch: {branch}")
+        if workflow_name:
+            print(f"  Workflow filter: {workflow_name}")
+        if job_name:
+            print(f"  Job filter: {job_name}")
+
+        pipelines = self.get_recent_pipelines(org, repo, branch)
+        print(f"\nFound {len(pipelines)} recent pipelines to check")
+
+        downloaded_count = 0
+
+        for pipeline in pipelines:
+            pipeline_id = pipeline["id"]
+            pipeline_number = pipeline["number"]
+            pipeline_state = pipeline.get("state", "unknown")
+
+            print(f"\nChecking pipeline #{pipeline_number} (state: {pipeline_state})")
+
+            try:
+                workflows = self.get_pipeline_workflows(pipeline_id)
+
+                for workflow in workflows:
+                    workflow_id = workflow["id"]
+                    workflow_name_actual = workflow["name"]
+                    workflow_status = workflow.get("status", "unknown")
+
+                    if workflow_name and workflow_name not in workflow_name_actual:
+                        continue
+
+                    if workflow_status != "success":
+                        print(f"  Skipping workflow '{workflow_name_actual}' (status: {workflow_status})")
+                        continue
+
+                    print(f"  Checking workflow: {workflow_name_actual}")
+
+                    jobs = self.get_workflow_jobs(workflow_id)
+
+                    for job in jobs:
+                        job_number = job["job_number"]
+                        job_name_actual = job["name"]
+                        job_status = job.get("status", "unknown")
+
+                        # Filter by job name if specified
+                        if job_name and job_name not in job_name_actual:
+                            continue
+
+                        if job_status != "success":
+                            continue
+
+                        print(f"    Checking job: {job_name_actual} (#{job_number})")
+
+                        artifacts = self.get_job_artifacts(job_number, org, repo)
+
+                        apk_artifacts = [
+                            a for a in artifacts
+                            if a.get("path", "").endswith(".apk")
+                        ]
+
+                        if apk_artifacts:
+                            print(f"    ✓ Found {len(apk_artifacts)} APK artifact(s)!")
+
+                            for artifact in apk_artifacts:
+                                artifact_path = artifact["path"]
+                                artifact_url = artifact["url"]
+                                filename = Path(artifact_path).name
+                                output_path = output_dir / filename
+
+                                print(f"Downloading: {filename}")
+                                print(f"From: {artifact_url}")
+                                print(f"To: {output_path}")
+
+                                try:
+                                    self.download_artifact(artifact_url, output_path)
+                                    print("✓ Downloaded successfully")
+                                    downloaded_count += 1
+                                except Exception as e:
+                                    print(f"        ✗ Download failed: {e}")
+
+                            # If we downloaded APKs, we're done
+                            if downloaded_count > 0:
+                                print(f"\n{'='*80}")
+                                print(f"Successfully downloaded {downloaded_count} APK(s) from:")
+                                print(f"Pipeline #{pipeline_number}")
+                                print(f"Workflow: {workflow_name_actual}")
+                                print(f"Job: {job_name_actual}")
+                                print(f"Saved to: {output_dir.resolve()}")
+                                print(f"{'='*80}")
+                                return downloaded_count
+
+            except Exception as e:
+                print(f"  Error checking pipeline #{pipeline_number}: {e}")
+                continue
+
+        if downloaded_count == 0:
+            print("\n✗ No APK artifacts found in recent successful jobs")
+            return 0
+
+        return downloaded_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Automatically find and download APK artifacts from CircleCI"
+    )
+    parser.add_argument(
+        "--org",
+        default="mozilla",
+        help="GitHub organization name (default: mozilla)"
+    )
+    parser.add_argument(
+        "--repo",
+        default="experimenter",
+        help="GitHub repository name (default: experimenter)"
+    )
+    parser.add_argument(
+        "--branch",
+        default="main",
+        help="Branch name (default: main)"
+    )
+    parser.add_argument(
+        "--workflow-name",
+        help="Workflow name filter (optional, matches substring)"
+    )
+    parser.add_argument(
+        "--job-name",
+        help="Job name filter (optional, matches substring)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Directory to save downloaded APKs (default: current directory)"
+    )
+    parser.add_argument(
+        "--token",
+        help="CircleCI API token (or set CIRCLECI_TOKEN env var)"
+    )
+
+    args = parser.parse_args()
+
+    fetcher = CircleCIArtifactFetcher(token=args.token)
+
+    downloaded = fetcher.find_and_download_apks(
+        org=args.org,
+        repo=args.repo,
+        output_dir=args.output_dir,
+        branch=args.branch,
+        workflow_name=args.workflow_name,
+        job_name=args.job_name,
+    )
+
+    if downloaded == 0:
+        print("\nFailed to download any APK artifacts")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utilities/start_android_klaatu_tests.sh
+++ b/utilities/start_android_klaatu_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ls
+cd klaatu
+adb install app-fenix-debug-androidTest.apk
+adb install app-fenix-x86_64-debug.apk
+cp -f tests/android/conftest.py ../firefox/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
+cp -f tests/android/generate_smoke_tests.py ../firefox/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
+cp -f tests/android/variables.yaml ../firefox/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
+cd ../firefox/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration
+pip3 install virtualenv poetry pipenv
+pipenv install
+pipenv install pytest-rerunfailures
+pipenv run python generate_smoke_tests.py
+echo "TEST COMMAND: pipenv run pytest --experiment-slug $SLUG --experiment-branch $BRANCH --experiment-server $EXPERIMENT_SERVER --experiment-feature $FEATURE_NAME --firefox-version $FIREFOX_VERSION $EXTRA_ARGUMENTS --reruns 1"
+pipenv run pytest --self-contained-html --experiment-slug "$SLUG" --experiment-branch "$BRANCH" --experiment-server "$EXPERIMENT_SERVER" --firefox-version "$FIREFOX_VERSION" --experiment-feature $FEATURE_NAME $EXTRA_ARGUMENTS --reruns 2 --maxfail=5 -rs tests/ || true


### PR DESCRIPTION
Our Android Klaatu tests have been failing since the move to Mozilla Central. This PR fixes those issues mainly by downloading a fenix test apk from experimenter's CI. This limits us to testing against the latest code in tree but I have confirmed that this will be a good solution until we can setup a way to build and store specific versions.

I have also updated the way the android emulator is run and it now uses a github action. This has been pretty reliable so far.

Fixes: https://mozilla-hub.atlassian.net/browse/EXP-6023