### PR TITLE
use env to pass output parameters

### DIFF
--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -53,8 +53,10 @@ jobs:
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: ${{ matrix.firefox }}
+        env:
+          FIREFOX_VERSION: ${{ steps.setup-firefox.outputs.firefox-version }}
       - run: |
-          echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+          echo Installed firefox versions: $FIREFOX_VERSION
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
use env to pass input and output parameters to prevent attacks from malicious input and dangerous writes, as described in [our guidelines](https://wiki.mozilla.org/GitHub/Repository_Security/GitHub_Workflows_%26_Actions#Perform_input_validation_and_encoding_on_Github_parameters).