### PR TITLE
chore(project): Change smoke test name in android actions file.

### DIFF
--- a/.github/workflows/android_manual.yml
+++ b/.github/workflows/android_manual.yml
@@ -19,11 +19,11 @@ on:
         type: string
       feature-name:
         description: 'The Feature you want to test'
-        default: 'smoke_test'
+        default: 'smoke'
         required: true
         type: choice
         options:
-          - smoke_test
+          - smoke
           - messaging_survey
           - messaging_homescreen
       experiment-server:

--- a/tests/android/generate_smoke_tests.py
+++ b/tests/android/generate_smoke_tests.py
@@ -101,7 +101,7 @@ def generate_smoke_tests(tests_names=None):
         test_name = test.replace("#", "_").lower()
         tests.append(
             f"""
-@pytest.mark.smoke_test
+@pytest.mark.smoke
 def test_smoke_{test_name}(setup_experiment, gradlewbuild, open_app):
     setup_experiment()
     open_app()


### PR DESCRIPTION
Because

- We had the wrong name for the smoke test suite in the github actions file for android

This commit

- Updates the name to match what we have in experimenter