### PR TITLE
chore(project): Update desktop workflows with correct server keyword.

### DIFF
--- a/.github/workflows/linux_manual.yml
+++ b/.github/workflows/linux_manual.yml
@@ -12,19 +12,27 @@ on:
         default: 'an-awesome-experiment'
         required: true
         type: string
-      server:
+      experiment-server:
         description: 'Experimenter Server'
         default: 'prod'
         required: false
         type: choice
         options:
           - stage
+          - stage/preview
           - prod
       firefox-version:
         description: 'The Firefox Version(s) you want to test'
         default: "['latest-beta', 'latest', '123.0']"
         required: false
         type: string
+      feature-name:
+        description: 'The Feature you want to test'
+        default: 'smoke'
+        required: false
+        type: choice
+        options:
+          - smoke
       extra-arguments:
         description: 'Additional testing arguments'
         default: ''
@@ -66,7 +74,7 @@ jobs:
             openssl req -x509 -newkey rsa:2048 -keyout search_files/server.key -out search_files/server.cert -days 365 -nodes -subj "/CN=localhost"
       - name: Run Tests
         run: |
-          tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.server}} --private-browsing-enabled --firefox-path="/opt/hostedtoolcache/firefox/${{ matrix.firefox }}/x64/firefox" ${{ inputs.extra-arguments }}
+          tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.experiment-server}} --private-browsing-enabled --firefox-path="/opt/hostedtoolcache/firefox/${{ matrix.firefox }}/x64/firefox" ${{ inputs.extra-arguments }}
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/windows_manual.yml
+++ b/.github/workflows/windows_manual.yml
@@ -13,19 +13,27 @@ on:
         default: 'an-awesome-experiment'
         required: true
         type: string
-      server:
+      experiment-server:
         description: 'Experimenter Server'
         default: 'prod'
         required: false
         type: choice
         options:
           - stage
+          - stage/preview
           - prod
       firefox-version:
         description: 'The Firefox Version(s) you want to test'
         default: "['latest-beta', 'latest', '123.0']"
         required: false
         type: string
+      feature-name:
+        description: 'The Feature you want to test'
+        default: 'smoke'
+        required: false
+        type: choice
+        options:
+          - smoke
       extra-arguments:
         description: 'Additional testing arguments'
         default: ''
@@ -86,7 +94,7 @@ jobs:
         run: |
           openssl req -x509 -newkey rsa:2048 -keyout search_files/server.key -out search_files/server.cert -days 365 -nodes -subj "//CN=localhost"
       - name: Run Tests
-        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.server}} --private-browsing-enabled --firefox-path "C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" --driver-path "C:\SeleniumWebDrivers\GeckoDriver\geckodriver.exe" ${{ inputs.extra-arguments }}
+        run: tox -e bdd-tests -- --experiment-branch ${{ matrix.branch }} --experiment-slug ${{ inputs.slug }} --experiment-server ${{inputs.experiment-server}} --private-browsing-enabled --firefox-path "C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe" --driver-path "C:\SeleniumWebDrivers\GeckoDriver\geckodriver.exe" ${{ inputs.extra-arguments }}
         env:
           SE_BROWSER_PATH: 'C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe'
           SE_OFFLINE: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_addoption(parser) -> None:
         "--experiment-server",
         action="store",
         default="prod",
-        choices=("prod", "stage"),
+        choices=("prod", "stage", "stage/preview"),
         help="The server where the experiment is located, either stage or prod",
     ),
     parser.addoption(
@@ -102,14 +102,19 @@ def fixture_experiment_json(request):
     slug_server = request.config.getoption("--experiment-server")
     experiment_json = request.config.getoption("--experiment-json")
 
+    prod = f"https://experimenter.services.mozilla.com/api/v6/experiments/{experiment_slug}"
+    stage = f"https://stage.experimenter.nonprod.webservices.mozgcp.net/api/v6/experiments/{experiment_slug}/"  # noqa: E501
+
     if experiment_json:
         with open(experiment_json) as f:
             return json.load(f)
     match slug_server:
         case "prod":
-            url = f"https://experimenter.services.mozilla.com/api/v6/experiments/{experiment_slug}/"  # noqa: E501
+            url = prod
         case "stage":
-            url = f"https://stage.experimenter.nonprod.webservices.mozgcp.net/api/v6/experiments/{experiment_slug}/"  # noqa: E501
+            url = stage
+        case "stage/preview":
+            url = stage
     return requests.get(url).json()
 
 


### PR DESCRIPTION
Because:

- We need to match the format we use for the mobile workflows as far as naming and keys added to the workflow files

This commit:

- Ensures desktop workflows match mobile

Fixes: #268 